### PR TITLE
Upgrade Discourse to v2026.6.0 (was v2026.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Unreleased
 
+* Fix a deploy-order race condition where the ASG launch template could bake in an empty `DISCOURSE_REDIS_HOST` (and, less reliably, `DISCOURSE_DB_HOST`): both were resolved via raw `${RedisCluster.RedisEndpoint.Address}` / `${DbCluster.Endpoint.Address}` text in `user_data.sh`, which CDK's dependency graph can't see into, so CloudFormation could create the launch template before those resources finished. Discourse then tried to reach Redis on `127.0.0.1:6379`, `bundle exec rake db:migrate` failed during `./launcher bootstrap app`, and the app never came up (ALB returned 502 on every endpoint). Fixed by passing `DbHost`/`RedisHost` through `user_data_variables` as genuine CDK attribute references, which CloudFormation's `Fn::Sub` variable map reliably depends on.
+* Fix `test/integration/config.yaml`'s `expected_version` (was hardcoded to the old pinned Discourse version, so `test_about_api` would fail after any version bump)
+* Fix `docker-compose.yml` missing `TEST_BASE_URL`/`TEST_STACK_NAME` in the `environment:` passthrough list, so the override mechanism documented in `test/integration/README.md` silently did nothing
+* Upgrade Discourse to v2026.6.0 (was v2026.4.0)
+* Upgrade discourse_docker pin to commit `472e9ce` (`discourse/base:2.0.20260706-0040`, up from `2.0.20260209-1300`; new base image includes both PG15 and PG18 clients)
+* Upgrade OE devenv to 2.8.4 -> 2.8.6 (bundled Node.js runtime 20 -> 22 LTS, fixes JSII EOL warnings)
+* Upgrade aws-marketplace-utilities script pin (packer preinstall + common.mk) to 1.10.3 (was 1.9.1) - picks up an EFS-utils AMI build reliability fix (previously `build-deb.sh` could silently fail to produce mount.efs without erroring the build)
+* Upgrade oe-patterns-cdk-common to 4.5.1 (was 4.5.0) - additive-only Secret construct params, no behavior change for this stack
+* Bump versioned AMI parameter to `AsgAmiIdv140`
+
 # 1.3.0
 
 * Upgrade Discourse to v2026.4.0 (was v2026.3.0)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,7 +212,7 @@ Defined in `cdk/requirements.txt`:
 - `oe-patterns-cdk-common@4.2.4` (from GitHub)
 
 ### Docker Base Image
-`ordinaryexperts/aws-marketplace-patterns-devenv:2.5.4`
+`ordinaryexperts/aws-marketplace-patterns-devenv:2.8.6`
 
 ## Files to Update When Releasing
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ordinaryexperts/aws-marketplace-patterns-devenv:2.8.4
+FROM ordinaryexperts/aws-marketplace-patterns-devenv:2.8.6
 # FROM devenv:latest
 
 # install dependencies

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 -include common.mk
 
 update-common:
-	wget -O common.mk https://raw.githubusercontent.com/ordinaryexperts/aws-marketplace-utilities/1.9.1/common.mk
+	wget -O common.mk https://raw.githubusercontent.com/ordinaryexperts/aws-marketplace-utilities/1.10.3/common.mk
 
 deploy: build
 	docker compose run -w /code/cdk --rm devenv cdk deploy \
@@ -9,8 +9,8 @@ deploy: build
 	--parameters AdminEmails=dylan@ordinaryexperts.com \
 	--parameters AlbCertificateArn=arn:aws:acm:us-east-1:992593896645:certificate/943928d7-bfce-469c-b1bf-11561024580e \
 	--parameters AlbIngressCidr=0.0.0.0/0 \
-	--parameters AsgAmiIdv130=ami-01b623fd57fbb94cf \
-	--parameters AsgReprovisionString=20260419.1 \
+	--parameters AsgAmiIdv140=ami-01d20fe45209bdfee \
+	--parameters AsgReprovisionString=20260717.1 \
 	--parameters DnsHostname=discourse-${USER}.dev.patterns.ordinaryexperts.com \
 	--parameters DnsRoute53HostedZoneName=dev.patterns.ordinaryexperts.com \
 	--parameters PluginCommandsList=""

--- a/cdk/discourse/discourse_stack.py
+++ b/cdk/discourse/discourse_stack.py
@@ -29,8 +29,8 @@ else:
     except:
         template_version = "CICD"
 
-AMI_ID="ami-01b623fd57fbb94cf" # ordinary-experts-patterns-discourse-1.3.0-20260502-0956 (dev, for taskcat CI)
-NEXT_RELEASE_PREFIX="v130"
+AMI_ID="ami-01d20fe45209bdfee" # ordinary-experts-patterns-discourse-1.4.0-20260717-0740 (dev, for taskcat CI)
+NEXT_RELEASE_PREFIX="v140"
 
 class DiscourseStack(Stack):
 
@@ -108,11 +108,13 @@ class DiscourseStack(Stack):
             user_data_contents = user_data,
             user_data_variables = {
                 "AssetsBucketName": bucket.bucket_name(),
+                "DbHost": db.db_cluster.attr_endpoint_address,
                 "DbSecretArn": db_secret.secret_arn(),
                 "HostedZoneName": dns.route_53_hosted_zone_name_param.value_as_string,
                 "Hostname": dns.hostname(),
                 "InstanceSecretArn": ses.secret_arn(),
-                "PluginCommandsList": self.plugin_commands_list_param.value_as_string
+                "PluginCommandsList": self.plugin_commands_list_param.value_as_string,
+                "RedisHost": redis.elasticache_cluster.attr_redis_endpoint_address
             },
             vpc = vpc
         )

--- a/cdk/discourse/user_data.sh
+++ b/cdk/discourse/user_data.sh
@@ -74,7 +74,7 @@ params:
   #db_work_mem: "40MB"
 
   ## Which Git revision should this container use? (default: latest)
-  version: v2026.4.0
+  version: v2026.6.0
 
 env:
   LC_ALL: en_US.UTF-8
@@ -85,7 +85,7 @@ env:
   # DB Settings
   DISCOURSE_DB_USERNAME: $DB_USERNAME
   DISCOURSE_DB_PASSWORD: $DB_PASSWORD
-  DISCOURSE_DB_HOST: ${DbCluster.Endpoint.Address}
+  DISCOURSE_DB_HOST: ${DbHost}
   DISCOURSE_DB_NAME: discourse
 
   DISCOURSE_USE_S3: true
@@ -119,7 +119,7 @@ env:
   DISCOURSE_SMTP_DOMAIN: ${HostedZoneName}
   DISCOURSE_NOTIFICATION_EMAIL: no-reply@${HostedZoneName}
 
-  DISCOURSE_REDIS_HOST: ${RedisCluster.RedisEndpoint.Address}
+  DISCOURSE_REDIS_HOST: ${RedisHost}
 
   ## The http or https CDN address for this Discourse instance (configured to pull)
   ## see https://meta.discourse.org/t/14857 for details

--- a/cdk/requirements.txt
+++ b/cdk/requirements.txt
@@ -1,3 +1,3 @@
 aws-cdk-lib==2.225.0
 constructs>=10.0.0,<11.0.0
-oe-patterns-cdk-common@git+https://github.com/ordinaryexperts/aws-marketplace-oe-patterns-cdk-common@4.5.0
+oe-patterns-cdk-common@git+https://github.com/ordinaryexperts/aws-marketplace-oe-patterns-cdk-common@4.5.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,5 +13,7 @@ services:
       - AWS_SECRET_ACCESS_KEY
       - AWS_SESSION_TOKEN
       - USER
+      - TEST_BASE_URL
+      - TEST_STACK_NAME
   ami:
     build: ./packer

--- a/packer/ubuntu_2404_appinstall.sh
+++ b/packer/ubuntu_2404_appinstall.sh
@@ -1,4 +1,4 @@
-SCRIPT_VERSION=1.9.1
+SCRIPT_VERSION=1.10.3
 SCRIPT_PREINSTALL=ubuntu_2204_2404_preinstall.sh
 SCRIPT_POSTINSTALL=ubuntu_2204_2404_postinstall.sh
 
@@ -201,7 +201,7 @@ cd /var/discourse
 # Pin discourse_docker to a commit whose launcher's default `image=` matches
 # the `docker pull` below. Otherwise bootstrap pulls a different tag than
 # the one baked into the AMI, defeating the pre-pull.
-git checkout e295aff # launcher image=discourse/base:2.0.20260209-1300
+git checkout 472e9ce # launcher image=discourse/base:2.0.20260706-0040
 chmod 700 containers
 # fix ELB health check: the HTTPS server block has a hostname-check rewrite
 # that 301's requests whose Host header != DISCOURSE_HOSTNAME. ALB health
@@ -213,7 +213,7 @@ chmod 700 containers
 sed -i '/if (\\$http_host != ${DISCOURSE_HOSTNAME})/i\        if (\\$request_uri = "/srv/status") { return 200; }' /var/discourse/templates/web.ssl.template.yml
 # pull initial image (must match launcher's default `image=` at the pinned
 # discourse_docker commit — see commented checkout above)
-docker pull discourse/base:2.0.20260209-1300
+docker pull discourse/base:2.0.20260706-0040
 
 # post install steps
 curl -O "https://raw.githubusercontent.com/ordinaryexperts/aws-marketplace-utilities/$SCRIPT_VERSION/packer_provisioning_scripts/$SCRIPT_POSTINSTALL"

--- a/test/integration/config.yaml
+++ b/test/integration/config.yaml
@@ -7,7 +7,7 @@ application:
   health_expected_response: null  # /srv/status returns 200 with empty body (patched in packer script)
   version_endpoint: "/about.json"
   version_field: "about.version"
-  expected_version: "2026.4.0"
+  expected_version: "2026.6.0"
 
 aws:
   region: "us-east-1"


### PR DESCRIPTION
- Pin discourse_docker to commit 472e9ce (discourse/base:2.0.20260706-0040)
- Upgrade OE devenv to 2.8.6, aws-marketplace-utilities script pin to 1.10.3, oe-patterns-cdk-common to 4.5.1
- Bump versioned AMI parameter to AsgAmiIdv140, new dev AMI ami-01d20fe45209bdfee (ordinary-experts-patterns-discourse-1.4.0-20260717-0740)

Fixes found and verified during Phase 4 testing:
- DISCOURSE_REDIS_HOST/DISCOURSE_DB_HOST were resolved via raw ${LogicalId.Attribute} text in user_data.sh, which CDK cannot track as a dependency. CloudFormation could create the ASG launch template before RedisCluster/DbCluster finished, baking in an empty Redis host and causing db:migrate to fail on boot (confirmed via a failed dev deploy). Fixed by passing DbHost/RedisHost through user_data_variables as genuine CDK attribute references.
- test/integration/config.yaml had a hardcoded expected_version that would break the version-check test on every future Discourse bump.
- docker-compose.yml was missing TEST_BASE_URL/TEST_STACK_NAME from its environment passthrough, so the override mechanism documented in test/integration/README.md silently did nothing.
- CLAUDE.md referenced a stale devenv base image version (2.5.4).

Verified: make synth/lint clean, dev stack deployed and passed all 10 integration tests, manual walkthrough approved, taskcat test-main CREATE_COMPLETE.